### PR TITLE
added one-hot encoding

### DIFF
--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -18,6 +18,17 @@ function to_long_mi(m::Matrix{Float64}, min_int, max_int)::Matrix{Int64}
     return @. round(Int64, m * δint / δmi + min_int)
 end
 
+###################
+# One-Hot Encoding
+####################
+
+function one_hot_encode(X::Array{T, 2}, categories::Array{T,1}) where {T<:Any}
+    X_dash = zeros(Bool, size(X)[1], length(categories)*size(X)[2])
+    for i = 1:size(X)[1], j = 1:size(X)[2]
+            X_dash[i, (j-1)*length(categories) + findfirst(==(X[i,j]), categories)] = 1
+    end  
+    X_dash
+end
 
 ###################
 # Testing Utils

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -21,7 +21,11 @@ end
 ###################
 # One-Hot Encoding
 ####################
-
+"""
+One-hot encode data (2-D Array) based on categories (1-D Array)
+Each row of the return value is a concatenation of one-hot encoding of elements of the same row in data
+Assumption: both input arrays have elements of same type
+"""
 function one_hot_encode(X::Array{T, 2}, categories::Array{T,1}) where {T<:Any}
     X_dash = zeros(Bool, size(X)[1], length(categories)*size(X)[2])
     for i = 1:size(X)[1], j = 1:size(X)[2]


### PR DESCRIPTION
Hello, I am working under Yitao in the weak-supervision project. This function enables one-hot encoding of data so that binary PSDDs can be created.

Test examples - 
example1 = [2 1 3; 3 2 3]
example2 = [true false]
example3 = ['a' 'a' 'b' 'd'; 'd' 'a' 'c' 'c'; 'b' 'a' 'c' 'd']
categories1 = [1, 2, 3]
categories2 = [false, true]
categories3 = ['d', 'c', 'b', 'a']