### PR TITLE
[WIP] BitCircuitPair: bit circuits for pair of ciruict (eg for expectations)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           julia --project -e 'using Pkg; Pkg.develop(PackageSpec(name="LogicCircuits")); Pkg.instantiate(); Pkg.build();'
           julia --project=test/ -e 'using Pkg; Pkg.instantiate(); Pkg.build();'
-          julia --project --check-bounds=yes --depwarn=error -e 'import Pkg; Pkg.test(; coverage=true)'
+          julia --project --check-bounds=yes -e 'import Pkg; Pkg.test(; coverage=true)'
       
       - name: Docs Build
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,14 @@ jobs:
           julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.build();'
           julia --project=test/ -e 'using Pkg; Pkg.instantiate(); Pkg.build();'
           julia --project --check-bounds=yes --depwarn=error -e 'import Pkg; Pkg.test(; coverage=true)'
+      
+      - name: Docs Build
+        run: |
+          sudo apt-get -qq update
+          sudo apt install -y pdf2svg texlive-latex-base texlive-binaries texlive-pictures texlive-latex-extra texlive-luatex    
+          luatex -v
+          pdflatex -v
+          julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(name="LogicCircuits")); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate();'
+          julia --project=docs/ docs/make.jl
+
+          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           julia --project -e 'using Pkg; Pkg.develop(PackageSpec(name="LogicCircuits")); Pkg.instantiate(); Pkg.build();'
           julia --project=test/ -e 'using Pkg; Pkg.instantiate(); Pkg.build();'
-          julia --project --check-bounds=yes -e 'import Pkg; Pkg.test(; coverage=true)'
+          julia --project --check-bounds=yes --depwarn=yes -e 'import Pkg; Pkg.test(; coverage=true)'
       
       - name: Docs Build
         env:

--- a/src/ProbabilisticCircuits.jl
+++ b/src/ProbabilisticCircuits.jl
@@ -19,6 +19,7 @@ include("plain_prob_nodes.jl")
 include("structured_prob_nodes.jl")
 include("logistic_nodes.jl")
 include("param_bit_circuit.jl")
+include("param_bit_circuit_pair.jl")
 include("parameters.jl")
 
 include("queries/likelihood.jl")
@@ -29,6 +30,7 @@ include("queries/pr_constraint.jl")
 include("queries/information.jl")
 include("queries/expectation_rec.jl")
 include("queries/expectation_graph.jl")
+include("queries/expectation_bit.jl")
 
 include("Logistic/Logistic.jl")
 @reexport using .Logistic

--- a/src/param_bit_circuit_pair.jl
+++ b/src/param_bit_circuit_pair.jl
@@ -34,7 +34,7 @@ end
 
 
 const NODES_LENGTH = 6
-const ELEMENTS_LENGTH = 5
+const ELEMENTS_LENGTH = 3
 
 """
 A bit circuit pair is a low-level representation of pairs of nodes traversed for a pair of probabilistic circuit logical circuit structure.
@@ -63,8 +63,6 @@ Elements are represented by a 5xE matrix, where
   * elements[1,:] is the Product pair node id,
   * elements[2,:] is the (left,left) child node id 
   * elements[3,:] is the (right right) child node id 
-  * elements[4,:] i for debugging, remove later (can assume the child ordering)
-  * elements[5,:] j
 """
 struct BitCircuitPair{V,M}#, WPC, WLC}
     layers::Vector{V}
@@ -213,12 +211,12 @@ function BitCircuitPair(pc::ProbCircuit, lc::LogisticCircuit; reset=true, on_sum
                     last_el_id += one(NodePairId)
                     
                     if typeof(cur) == ProdNodePairIds
-                        push!(elements, last_dec_id, cur.left_left_id, cur.right_right_id, NodeId(i), NodeId(j));
+                        push!(elements, last_dec_id, cur.left_left_id, cur.right_right_id);
                         @inbounds push!(parents[cur.left_left_id], last_el_id)
                         @inbounds push!(parents[cur.right_right_id], last_el_id)
                     else
                         @assert children(m)[1] isa LogisticLeafNode
-                        push!(elements, last_dec_id, cur.node_id, cur.node_id, NodeId(i), NodeId(j));
+                        push!(elements, last_dec_id, cur.node_id, cur.node_id);
                         @inbounds push!(parents[cur.node_id], last_el_id)
                         @inbounds push!(parents[cur.node_id], last_el_id)
                     end

--- a/src/param_bit_circuit_pair.jl
+++ b/src/param_bit_circuit_pair.jl
@@ -309,7 +309,7 @@ to_gpu(c::ParamBitCircuitPair) =
         to_gpu(c.bcp), to_gpu(c.pc_params), to_gpu(c.lc_params))
 
 to_cpu(c::ParamBitCircuitPair) = 
-    ParamBitCircuitPair(to_cpu(c.pc_bit), to_cpu(c.lc_bit), to_cpu(bcp), to_cpu(pc_params), to_cpu(lc_params))
+    ParamBitCircuitPair(to_cpu(c.pc_bit), to_cpu(c.lc_bit), to_cpu(c.bcp), to_cpu(c.pc_params), to_cpu(c.lc_params))
 
 isgpu(c::ParamBitCircuitPair) = 
-    isgpu(c.pc_bit) && isgpu(c.lc_bit) && isgpu(c.bcp) && isgpu(pc_params) && isgpu(lc_params)
+    isgpu(c.pc_bit) && isgpu(c.lc_bit) && isgpu(c.bcp) && isgpu(c.pc_params) && isgpu(c.lc_params)

--- a/src/param_bit_circuit_pair.jl
+++ b/src/param_bit_circuit_pair.jl
@@ -1,0 +1,273 @@
+using CUDA
+
+export NodePairIds, 
+       BitCircuitPair,
+       SumNodePairIds,
+       ProdNodePairIds,
+       BitCircuitPair,
+       ParamBitCircuitPair
+
+const NodeId = Int32 
+
+"Integer identifier for a circuit pair node"
+const NodePairId = Int32 
+
+"The BitCircuitPair ids associated with a node"
+abstract type NodePairIds end
+
+mutable struct SumNodePairIds <: NodePairIds 
+    layer_id::NodePairId
+    node_id::NodePairId
+end
+
+mutable struct ProdNodePairIds <: NodePairIds
+    layer_id::NodePairId
+    # Assuming both Product nodes have two children
+    left_left_id::NodePairId
+    right_right_id::NodePairId
+
+    ProdNodePairIds(ll::SumNodePairIds, rr::SumNodePairIds) = begin
+        l = max(ll.layer_id, rr.layer_id)
+        new(l, ll.node_id, rr.node_id)
+    end 
+end
+
+
+const NODES_LENGTH = 6
+const ELEMENTS_LENGTH = 5
+
+"""
+A bit circuit pair is a low-level representation of pairs of nodes traversed for a pair of probabilistic circuit logical circuit structure.
+For example, this is used for taking expectation of a Logistic/Regression circuit w.r.t. a probabilistic circuit.
+
+The wiring of the circuit is captured by two matrices: nodes and elements.
+  * Nodes are either leafs (input) or pair of Sum nodes
+  * Elements are Pair of Product nodes 
+  * In addition, there is a vector of layers, where each layer is a list of node ids.
+    Layer 1 is the leaf/input layer. Layer end is the circuit root.
+  * And there is a vector of parents, pointing to element id parents of decision nodes.
+
+Nodes are represented as a 6xN matrix where
+  * nodes[1,:] is the first child pair id 
+  * nodes[2,:] is the last child pair id 
+  * nodes[3,:] is the first parent index 
+  * nodes[4,:] is the last parent index 
+  * nodes[5,:] is the id of corresponding node from the PC (first circuit)
+  * nodes[6,:] is the id of corresponding node from the LC (first circuit)
+
+
+  Elements belonging to node pair `i` are `elements[:, nodes[1,i]:nodes[2,i]]` 
+  Parents belonging to node pair `i` are `parents[nodes[3,i]:nodes[4,i]]`
+
+Elements are represented by a 5xE matrix, where 
+  * elements[1,:] is the Product pair node id,
+  * elements[2,:] is the (left,left) child node id 
+  * elements[3,:] is the (right right) child node id 
+  * elements[4,:] i for debugging, remove later (can assume the child ordering)
+  * elements[5,:] j
+"""
+struct BitCircuitPair{V,M}#, WPC, WLC}
+    layers::Vector{V}
+    nodes::M
+    elements::M
+    parents::V
+end
+
+
+struct ParamBitCircuitPair{V,M, WPC, WLC}
+    pc_bit::BitCircuit{V,M}
+    lc_bit::BitCircuit{V,M}
+    bcp::BitCircuitPair{V,M}
+    pc_params::WPC
+    lc_params::WLC
+end
+
+function ParamBitCircuitPair(pc::ProbCircuit, lc::LogisticCircuit, data; reset=true)
+    pc_thetas::Vector{Float64} = Vector{Float64}()
+    lc_thetas::Vector{Vector{Float32}} = Vector{Vector{Float32}}()
+
+    sizehint!(pc_thetas, num_edges(pc))
+
+    pc_cache = Dict{Node, NodeId}() # only for sum nodes
+    lc_cache = Dict{Node, NodeId}() # only for sum nodes
+
+    lc_num_classes = num_classes(lc);
+
+    pc_on_decision(n, cs, layer_id, decision_id, first_element, last_element) = begin
+        if isnothing(n) # this decision node is not part of the PC
+            push!(pc_thetas, 0.0)
+        else
+            pc_cache[n] = decision_id
+            append!(pc_thetas, n.log_probs)
+        end
+    end
+
+    lc_on_decision(m, cs, layer_id, decision_id, first_element, last_element) = begin
+        if isnothing(m)
+            throw("here, some node is not part of the logistic circuit")
+            # push!(lc_thetas, zeros(Float32, lc_num_classes))            
+        else
+            lc_cache[m] = decision_id
+            for theta in eachrow(m.thetas)
+                push!(lc_thetas, theta)
+            end
+        end
+    end
+
+    pbc_callback(n, m, results, layer_id, last_dec_id, first_el_id, last_el_id) = begin
+        nothing
+    end
+
+    pc_bit = BitCircuit(pc, data; reset=reset, on_decision=pc_on_decision)
+    lc_bit = BitCircuit(lc, data; reset=reset, on_decision=lc_on_decision)
+    bcp = BitCircuitPair(pc, lc; reset, on_sum_callback = pbc_callback, pc_cache, lc_cache)
+    
+    lc_thetas_reshaped = permutedims(hcat(lc_thetas...), (2, 1))
+
+    ParamBitCircuitPair(pc_bit, lc_bit, bcp, pc_thetas, lc_thetas_reshaped)
+end
+
+
+function BitCircuitPair(pc::ProbCircuit, lc::LogisticCircuit; reset=true, on_sum_callback=noop, 
+    pc_cache=nothing, lc_cache=nothing)
+
+    @assert num_variables(pc) == num_variables(lc)
+    # TODO check if they both have same vtree
+
+    num_features = num_variables(pc)
+    num_leafs = 4*num_features
+    layers::Vector{Vector{NodePairId}} = Vector{NodePairId}[collect(1:num_leafs)]
+    nodes::Vector{NodePairId} = zeros(NodePairId, NODES_LENGTH*num_leafs)
+    elements::Vector{NodePairId} = NodePairId[]
+    parents::Vector{Vector{NodePairId}} = Vector{NodePairId}[NodePairId[] for i = 1:num_leafs]
+    last_dec_id::NodePairId = 4*num_features
+    last_el_id::NodePairId = zero(NodePairId)
+
+    cache = Dict{Pair{Node, Node}, NodePairIds}()
+
+    func(n,m) = begin
+        throw("This should not happen!! $n, $m")
+    end
+
+    function func(n::Union{PlainProbLiteralNode, StructProbLiteralNode}, 
+                    m::LogisticLiteralNode)::NodePairIds
+        get!(cache, Pair(n, m)) do
+            @assert variable(n) == variable(m)
+            if ispositive(n) && ispositive(m)
+                SumNodePairIds(one(NodePairId), NodePairId(variable(n)))
+            elseif !ispositive(n) && ispositive(m)
+                SumNodePairIds(one(NodePairId), NodePairId(variable(n) + num_features))
+            elseif ispositive(n) && !ispositive(m)
+                SumNodePairIds(one(NodePairId), NodePairId(variable(n) + 2*num_features))
+            elseif !ispositive(n) && !ispositive(m)
+                SumNodePairIds(one(NodePairId), NodePairId(variable(n) + 3*num_features))
+            end
+        end
+    end
+
+    function func(n::Union{PlainProbLiteralNode, StructProbLiteralNode}, 
+                    m::Logistic⋁Node)::NodePairIds
+        
+        @assert num_children(m) == 1
+        func(n, children(m)[1])
+    end
+
+    function func(n::Union{PlainMulNode, StructMulNode}, 
+            m::Logistic⋀Node)::NodePairIds
+        
+        get!(cache, Pair(n, m)) do
+            @assert num_children(n) == 2
+            @assert num_children(m) == 2
+
+            ll = func(children(n)[1], children(m)[1])
+            rr = func(children(n)[2], children(m)[2])
+            ProdNodePairIds(ll, rr)
+        end
+    end
+
+
+    function func(n::Union{PlainSumNode, StructSumNode}, 
+                    m::Logistic⋁Node)::NodePairIds
+        
+        get!(cache, Pair(n, m)) do 
+            
+        
+            # First process the children
+            results::Vector{Vector{NodePairIds}} = NodePairIds[]
+            for i in 1:num_children(n)
+                push!(results, NodePairIds[])
+                for j in 1:num_children(m)
+                    #results[i][j] = func(children(n)[i], children(m)[j])
+                    push!(results[i], func(children(n)[i], children(m)[j]))
+                end
+            end
+
+            first_el_id::NodePairId = last_el_id + one(NodePairId)
+            layer_id::NodePairId = zero(NodePairId)
+            push!(parents, NodePairId[])
+
+            
+
+            for i in 1:num_children(n)
+                for j in 1:num_children(m)
+                    cur = results[i][j];  
+                    layer_id = max(layer_id, cur.layer_id)
+
+                    # if !(children(m)[1] isa LogisticLeafNode)
+                    last_el_id += one(NodePairId)
+                    # end
+
+
+                    if typeof(cur) == ProdNodePairIds
+                        push!(elements, last_dec_id, cur.left_left_id, cur.right_right_id, NodeId(i), NodeId(j));
+                        @inbounds push!(parents[cur.left_left_id], last_el_id)
+                        @inbounds push!(parents[cur.right_right_id], last_el_id)
+                    else
+                        @assert children(m)[1] isa LogisticLeafNode
+                        push!(elements, last_dec_id, cur.node_id, cur.node_id, NodeId(i), NodeId(j));
+                        @inbounds push!(parents[cur.node_id], last_el_id)
+                        @inbounds push!(parents[cur.node_id], last_el_id)
+                    end
+                end
+            end
+            layer_id += one(NodePairId)
+            length(layers) < layer_id && push!(layers, NodePairId[])
+
+            last_dec_id::NodePairId += one(NodePairId)
+
+            PC_ID = pc_cache !== nothing ? pc_cache[n] : zero(NodePairId)
+            LC_ID = lc_cache !== nothing ? lc_cache[m] : zero(NodePairId)
+
+            push!(nodes, first_el_id, last_el_id, zero(NodePairId), zero(NodePairId), PC_ID, LC_ID)
+            push!(layers[layer_id], last_dec_id)
+            on_sum_callback(n, m, results, layer_id, last_dec_id, first_el_id, last_el_id)
+            SumNodePairIds(layer_id, last_dec_id)
+        end
+    end
+
+    # Call on roots
+    func(pc, children(lc)[1]) # skipping bias node of LC
+
+    nodes_m = reshape(nodes, NODES_LENGTH, :)
+    elements_m = reshape(elements, ELEMENTS_LENGTH, :)
+    parents_m = Vector{NodePairId}(undef, size(elements_m,2)*2)
+
+    last_parent = zero(NodePairId)[]
+    @assert last_dec_id == size(nodes_m,2) == size(parents,1)
+    @assert sum(length, parents) == length(parents_m)
+    for i in 1:last_dec_id-1
+        if !isempty(parents[i])
+            nodes_m[3,i] = last_parent + one(NodePairId)
+            parents_m[last_parent + one(NodePairId):last_parent + length(parents[i])] .= parents[i] 
+            last_parent += length(parents[i])
+            nodes_m[4,i] = last_parent
+        else
+            @assert i <= num_leafs "Only root and leaf nodes can have no parents: $i <= $num_leafs"
+        end
+    end
+    return BitCircuitPair(layers, nodes_m, elements_m, parents_m)
+end
+
+
+
+

--- a/src/queries/expectation_bit.jl
+++ b/src/queries/expectation_bit.jl
@@ -1,0 +1,120 @@
+using CUDA: CUDA, @cuda
+using DataFrames: DataFrame
+using LoopVectorization: @avx
+
+export ExpectationBit
+
+function ExpectationBit(pc::ProbCircuit, lc::LogisticCircuit, data)
+    pbc = ParamBitCircuitPair(pc, lc, data);
+    ExpectationBit(pbc, pc, lc, data);
+end
+
+function ExpectationBit(pbc::ParamBitCircuitPair, pc::ProbCircuit, lc::LogisticCircuit, data)
+    # 1. Get probability of each observation
+    parambit = ParamBitCircuit(pbc.pc_bit, pbc.pc_params);
+    log_likelihoods = MAR(parambit, data);
+    p_observed = exp.( log_likelihoods )
+    
+    # 2. Expectation w.r.t. P(x_m, x_o)
+    fvalues, gvalues = init_expectations(pbc, data, nothing, nothing, size(pbc.bcp.nodes)[2], num_classes(lc))
+    expectation_layers(pbc, fvalues, gvalues)
+    results_unnormalized = gvalues[:, end,:]
+
+    # 3. Expectation w.r.t P(x_m | x_o)
+    results = results_unnormalized ./ p_observed
+    
+    # # 4. Add Bias terms
+    biases = lc.thetas
+    results .+= biases
+    
+    results, fvalues, gvalues, pbc
+end
+
+function init_expectations(circuit::ParamBitCircuitPair, data, reuse_f, reuse_g, nodes_num, classes_num; Float=Float32)
+    flowtype = isgpu(data) ? CuArray{Float} : Array{Float}
+    fvalues = similar!(reuse_f, flowtype, num_examples(data), nodes_num)
+    fgvalues = similar!(reuse_g, flowtype, num_examples(data), nodes_num, classes_num)
+
+    # This is all only O(nfeatures) so was not worth doing parallization or on GPU
+    data_cpu = to_cpu(data)
+    nfeatures = num_features(data)
+
+    fvalues[:,:] .= Float(0.0)   
+    fgvalues[:,:,:] .= Float(0.0)  
+
+    PARS = circuit.lc_params
+    for var=1:nfeatures
+        fvalues[.!isequal.(data_cpu[:, var], 0), var] .= Float(1.0)
+        fvalues[.!isequal.(data_cpu[:, var], 1), var + 3*nfeatures] .= Float(1.0)
+
+        
+        # find the index of correct paramter to grab from LogisticCircuit
+        p_ind = circuit.lc_bit.parents[circuit.lc_bit.nodes[3, 2+var]]
+        p_ind2 = circuit.lc_bit.parents[circuit.lc_bit.nodes[3, 2+var+nfeatures]]
+
+        for cc=1:classes_num
+            fgvalues[:, var, cc] .= (fvalues[:, var] .* PARS[p_ind,cc])
+            ind2 = var + 3*nfeatures
+            fgvalues[:, ind2, cc] .= (fvalues[:, ind2] .* PARS[p_ind2,cc])
+        end
+    end
+    return fvalues, fgvalues
+end
+
+function expectation_layers(circuit, fvalues, fgvalues)
+    bcp::BitCircuitPair = circuit.bcp
+    pc::BitCircuit = circuit.pc_bit
+    lc::BitCircuit = circuit.lc_bit
+    els = bcp.elements
+    pc_pars = circuit.pc_params
+    lc_pars = circuit.lc_params
+
+    for layer in bcp.layers[2:end]
+        Threads.@threads for dec_id in layer
+            
+            id_begin = @inbounds bcp.nodes[1, dec_id]
+            id_end   = @inbounds bcp.nodes[2, dec_id]
+            pc_id    = @inbounds bcp.nodes[5, dec_id]
+            lc_id    = @inbounds bcp.nodes[6, dec_id]
+            # println("!!, $dec_id,  $id_begin, $id_end, $pc_id, $lc_id")
+
+            @inbounds pc_childs = 1 + pc.nodes[2, pc_id] - pc.nodes[1, pc_id]
+            @inbounds lc_childs = 1 + lc.nodes[2, lc_id] - lc.nodes[1, lc_id]
+            for A =  1 : pc_childs
+                for B = 1 : lc_childs
+                    shift = (A-1) * lc_childs + B
+                    Z = id_begin + shift - 1
+                    @inbounds PCZ = pc.nodes[1, pc_id] + A - 1
+                    @inbounds LCZ = lc.nodes[1, lc_id] + B - 1
+
+                    ## Compute fvalues[:, dec_id]
+                    
+                    @inbounds @fastmath @avx fvalues[:, dec_id] .+= exp(pc_pars[PCZ]) .* 
+                        fvalues[:, els[2,Z]] .* 
+                        fvalues[:, els[3,Z]]
+
+                    ## Compute fgvalues[:, dec_id, :]
+                    if els[3,Z] == els[2,Z]
+                        # Special case (end in sum nodes)
+                        @inbounds @fastmath @views @avx fgvalues[:, dec_id, :] .= 
+                            transpose(lc_pars[LCZ,:]) .* 
+                            fvalues[:, dec_id] 
+                    else
+                        @inbounds @fastmath @avx fgvalues[:, dec_id, :] .+=  
+                            exp(pc_pars[PCZ]) .* 
+                            transpose(lc_pars[LCZ,:]) .* 
+                            (fvalues[:, els[2,Z]] .* fvalues[:, els[3,Z]])
+
+                        @inbounds @fastmath @avx fgvalues[:, dec_id, :] .+= 
+                            exp(pc_pars[PCZ]) .* 
+                            ((fvalues[:, els[3,Z]] .* fgvalues[:, els[2,Z], :]) .+ 
+                            (fvalues[:, els[2,Z]] .* fgvalues[:, els[3,Z], :]))
+                    end
+                    
+                end # B
+            end # A  
+
+        end # dec_id
+    end # layers
+    
+end

--- a/src/queries/expectation_bit.jl
+++ b/src/queries/expectation_bit.jl
@@ -6,6 +6,9 @@ export ExpectationBit
 
 function ExpectationBit(pc::ProbCircuit, lc::LogisticCircuit, data)
     pbc = ParamBitCircuitPair(pc, lc, data);
+    if isgpu(data)
+        pbc = to_gpu(pbc)
+    end
     ExpectationBit(pbc, pc, lc, data);
 end
 
@@ -17,11 +20,16 @@ function ExpectationBit(pbc::ParamBitCircuitPair, pc::ProbCircuit, lc::LogisticC
     
     # 2. Expectation w.r.t. P(x_m, x_o)
     fvalues, gvalues = init_expectations(pbc, data, nothing, nothing, size(pbc.bcp.nodes)[2], num_classes(lc))
+
     expectation_layers(pbc, fvalues, gvalues)
     results_unnormalized = gvalues[:, end,:]
 
     # 3. Expectation w.r.t P(x_m | x_o)
     results = results_unnormalized ./ p_observed
+    
+    if isgpu(results)
+        results = to_cpu(results)
+    end
     
     # # 4. Add Bias terms
     biases = lc.thetas
@@ -31,7 +39,7 @@ function ExpectationBit(pbc::ParamBitCircuitPair, pc::ProbCircuit, lc::LogisticC
 end
 
 function init_expectations(circuit::ParamBitCircuitPair, data, reuse_f, reuse_g, nodes_num, classes_num; Float=Float32)
-    flowtype = isgpu(data) ? CuArray{Float} : Array{Float}
+    flowtype = Array{Float} #isgpu(data) ? CuArray{Float} : Array{Float}
     fvalues = similar!(reuse_f, flowtype, num_examples(data), nodes_num)
     fgvalues = similar!(reuse_g, flowtype, num_examples(data), nodes_num, classes_num)
 
@@ -39,34 +47,38 @@ function init_expectations(circuit::ParamBitCircuitPair, data, reuse_f, reuse_g,
     data_cpu = to_cpu(data)
     nfeatures = num_features(data)
 
-    fvalues[:,:] .= Float(0.0)   
-    fgvalues[:,:,:] .= Float(0.0)  
+    fvalues[:,:] .= zero(Float)
+    fgvalues[:,:,:] .= zero(Float)
 
     PARS = circuit.lc_params
     for var=1:nfeatures
-        fvalues[.!isequal.(data_cpu[:, var], 0), var] .= Float(1.0)
-        fvalues[.!isequal.(data_cpu[:, var], 1), var + 3*nfeatures] .= Float(1.0)
+        fvalues[.!isequal.(data_cpu[:, var], 0), var] .= one(Float)
+        fvalues[.!isequal.(data_cpu[:, var], 1), var + 3*nfeatures] .= one(Float)
 
-        
+        ind2 = var + 3*nfeatures
         # find the index of correct paramter to grab from LogisticCircuit
         p_ind = circuit.lc_bit.parents[circuit.lc_bit.nodes[3, 2+var]]
         p_ind2 = circuit.lc_bit.parents[circuit.lc_bit.nodes[3, 2+var+nfeatures]]
 
         for cc=1:classes_num
             fgvalues[:, var, cc] .= (fvalues[:, var] .* PARS[p_ind,cc])
-            ind2 = var + 3*nfeatures
             fgvalues[:, ind2, cc] .= (fvalues[:, ind2] .* PARS[p_ind2,cc])
         end
     end
-    return fvalues, fgvalues
+
+    if isgpu(data)
+        return to_gpu(fvalues), to_gpu(fgvalues)
+    else
+        return fvalues, fgvalues
+    end
 end
 
-function expectation_layers(circuit, fvalues, fgvalues)
+function expectation_layers(circuit, fvalues::Array{<:AbstractFloat,2}, fgvalues::Array{<:AbstractFloat,3})
     bcp::BitCircuitPair = circuit.bcp
     pc::BitCircuit = circuit.pc_bit
     lc::BitCircuit = circuit.lc_bit
     els = bcp.elements
-    pc_pars = circuit.pc_params
+    pc_pars = exp.(circuit.pc_params)
     lc_pars = circuit.lc_params
 
     for layer in bcp.layers[2:end]
@@ -89,7 +101,7 @@ function expectation_layers(circuit, fvalues, fgvalues)
 
                     ## Compute fvalues[:, dec_id]
                     
-                    @inbounds @fastmath @avx fvalues[:, dec_id] .+= exp(pc_pars[PCZ]) .* 
+                    @inbounds @fastmath @avx fvalues[:, dec_id] .+= pc_pars[PCZ] .* 
                         fvalues[:, els[2,Z]] .* 
                         fvalues[:, els[3,Z]]
 
@@ -101,12 +113,12 @@ function expectation_layers(circuit, fvalues, fgvalues)
                             fvalues[:, dec_id] 
                     else
                         @inbounds @fastmath @avx fgvalues[:, dec_id, :] .+=  
-                            exp(pc_pars[PCZ]) .* 
+                            pc_pars[PCZ] .* 
                             transpose(lc_pars[LCZ,:]) .* 
                             (fvalues[:, els[2,Z]] .* fvalues[:, els[3,Z]])
 
                         @inbounds @fastmath @avx fgvalues[:, dec_id, :] .+= 
-                            exp(pc_pars[PCZ]) .* 
+                            pc_pars[PCZ] .* 
                             ((fvalues[:, els[3,Z]] .* fgvalues[:, els[2,Z], :]) .+ 
                             (fvalues[:, els[2,Z]] .* fgvalues[:, els[3,Z], :]))
                     end
@@ -117,4 +129,86 @@ function expectation_layers(circuit, fvalues, fgvalues)
         end # dec_id
     end # layers
     
+end
+
+function expectation_layers(circuit::ParamBitCircuitPair, 
+    fvalues::CuArray, fgvalues::CuArray; 
+    dec_per_thread = 8, log2_threads_per_block = 8)
+
+    bcp = circuit.bcp
+    pc_pars = exp.(circuit.pc_params)
+
+    CUDA.@sync for layer in bcp.layers[2:end]
+        num_examples = size(fvalues, 1)
+        num_decision_sets = length(layer)/dec_per_thread
+        num_threads =  balance_threads(num_examples, num_decision_sets, log2_threads_per_block)
+        num_blocks = (ceil(Int, num_examples/num_threads[1]), 
+                      ceil(Int, num_decision_sets/num_threads[2]))
+
+        @cuda threads=num_threads blocks=num_blocks expectation_layers_cuda(layer, bcp.nodes, bcp.elements, 
+            circuit.pc_bit.nodes, circuit.lc_bit.nodes,
+            pc_pars, circuit.lc_params, fvalues, fgvalues)
+    end
+    return nothing
+end
+
+function expectation_layers_cuda(layer, nodes, els, 
+    pc_nodes, lc_nodes, 
+    pc_pars, lc_pars, fvalues, fgvalues)
+
+    num_classes = size(lc_pars, 2)
+
+    index_x = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    index_y = (blockIdx().y - 1) * blockDim().y + threadIdx().y
+    stride_x = blockDim().x * gridDim().x
+    stride_y = blockDim().y * gridDim().y
+    for j = index_x:stride_x:size(fvalues,1)
+        for i = index_y:stride_y:length(layer)
+            @inbounds dec_id =  layer[i]
+            @inbounds id_begin  =  nodes[1, dec_id]
+            @inbounds id_end    =  nodes[2, dec_id]
+            @inbounds pc_id     =  nodes[5, dec_id]
+            @inbounds lc_id     =  nodes[6, dec_id]
+            @inbounds pc_childs = 1 + pc_nodes[2, pc_id] - pc_nodes[1, pc_id]
+            @inbounds lc_childs = 1 + lc_nodes[2, lc_id] - lc_nodes[1, lc_id]
+
+            for A =  1 : pc_childs
+                for B = 1 : lc_childs
+                    shift = (A-1) * lc_childs + B
+                    Z = id_begin + shift - 1
+                    @inbounds PCZ = pc_nodes[1, pc_id] + A - 1
+                    @inbounds LCZ = lc_nodes[1, lc_id] + B - 1
+
+                    ## Compute fvalues[:, dec_id]
+                    fvalues[j, dec_id] += pc_pars[PCZ] * 
+                        fvalues[j, els[2,Z]] * 
+                        fvalues[j, els[3,Z]]
+
+                    ## Compute fgvalues[:, dec_id, :]
+                    if els[3,Z] == els[2,Z]
+                        # Special case (end in sum nodes)
+                        for class=1:num_classes
+                            @inbounds fgvalues[j, dec_id, class] = 
+                                lc_pars[LCZ,class] * 
+                                fvalues[j, dec_id] 
+                        end
+                    else
+                        for class=1:num_classes
+                            fgvalues[j, dec_id, class] +=  
+                                pc_pars[PCZ] * 
+                                lc_pars[LCZ,class] * 
+                                (fvalues[j, els[2,Z]] * fvalues[j, els[3,Z]])
+                        
+                            fgvalues[j, dec_id, class] += 
+                                pc_pars[PCZ] * 
+                                ((fvalues[j, els[3,Z]] * fgvalues[j, els[2,Z], class]) + 
+                                (fvalues[j, els[2,Z]] * fgvalues[j, els[3,Z], class]))
+                        
+                        end
+                    end
+                end # B
+            end # A  
+        end # i
+    end # j
+    return nothing
 end

--- a/src/queries/marginal_flow.jl
+++ b/src/queries/marginal_flow.jl
@@ -47,7 +47,7 @@ end
 """
     MAR(pc, data)
 
-Computes Marginal log likelhood of data.  
+Computes Marginal log likelhood of data. See docs for `marginal`.
 """
 const MAR = marginal
 

--- a/test/broken/Logistic/param_bit_circuit_pair_test.jl
+++ b/test/broken/Logistic/param_bit_circuit_pair_test.jl
@@ -1,0 +1,53 @@
+using Test
+using LogicCircuits
+using ProbabilisticCircuits
+using Random
+
+@testset "BitCircuitPair test" begin
+
+end
+
+
+@testset "ParamBitCircuitPair test" begin
+
+    function test_integrity(pbc::ParamBitCircuitPair)
+        bc = pbc.pair_bit
+        @test num_elements(pbc) == size(bc.elements, 2)
+        for el in 1:size(bc.elements,2)
+            d = bc.elements[1,el]
+            @test bc.nodes[1,d] <= el
+            
+            @test bc.nodes[2,d] >= el  #TODO this line fails
+            p = bc.elements[2,el]
+            @test el ∈ bc.parents[bc.nodes[3,p]:bc.nodes[4,p]]
+            s = bc.elements[3,el]
+            @test el ∈ bc.parents[bc.nodes[3,s]:bc.nodes[4,s]]
+        end
+        for node in 1:size(bc.nodes,2)
+            first_el = bc.nodes[1,node]
+            last_el = bc.nodes[2,node]
+            if first_el != 0
+                for i = first_el:last_el
+                    @test bc.elements[1,i] == node #TODO this line fails (its node-1 instead for some reason)
+                end
+            end
+            first_par = bc.nodes[3,node]
+            last_par = bc.nodes[3,node]
+            if first_par != 0
+                for i = first_par:last_par
+                    par = bc.parents[i]
+                    @test bc.elements[2,par] == node || bc.elements[3,par] == node
+                end
+            else
+                @test node == num_nodes(pbc) || node <= num_leafs(pbc)
+            end
+        end
+        @test sum(length, bc.layers) == size(bc.nodes,2)
+    end
+
+    pc = zoo_psdd("exp-D15-N1000-C4.psdd");
+    lc = zoo_lc("exp-D15-N1000-C4.circuit", 4);
+
+    test_integrity(ParamBitCircuitPair(pc, children(lc)[1]));
+
+end

--- a/test/queries/expectation_tests.jl
+++ b/test/queries/expectation_tests.jl
@@ -2,10 +2,10 @@ using Test
 using LogicCircuits
 using ProbabilisticCircuits
 using DataFrames
-
+using CUDA
 
 function test_expectation_brute_force(pc::ProbCircuit, lc::LogisticCircuit, data, CLASSES::Int)
-    EPS = 1e-4;
+    EPS = 1e-5;
     COUNT = size(data)[1]
     # Compute True expectation brute force
     true_exp = zeros(COUNT, CLASSES)
@@ -34,6 +34,29 @@ function test_expectation_brute_force(pc::ProbCircuit, lc::LogisticCircuit, data
             @test true_exp[i,j] ≈ calc_exp_2[i,j] atol= EPS;
         end
     end
+    # Compute BitCircuit Expectations (CPU)
+    bit_exps, fvalues, gvalues, pbc_cpu = ExpectationBit(pc, lc, data; return_aux=true)
+    bit_exps_batch2 = ExpectationBit(pbc_cpu, pc, lc, data, fvalues, gvalues; return_aux=false)
+    for i = 1:COUNT
+        for j = 1:CLASSES
+            @test true_exp[i,j] ≈ bit_exps[i,j] atol= EPS;
+            @test true_exp[i,j] ≈ bit_exps_batch2[i,j] atol= EPS;
+        end
+    end
+
+    # Compute BitCircuit Expectations (GPU)
+    if CUDA.functional()
+        data_gpu = to_gpu(data);
+        bit_exps_gpu, fvalues, gvalues, pbc_gpu = ExpectationBit(pc, lc, data_gpu; return_aux=true)
+        bit_exps_gpu_2 = ExpectationBit(pbc_gpu, pc, lc, data_gpu, fvalues, gvalues; return_aux=false)
+        for i = 1:COUNT
+            for j = 1:CLASSES
+                @test true_exp[i,j] ≈ bit_exps_gpu[i,j] atol= EPS;
+                @test true_exp[i,j] ≈ bit_exps_gpu_2[i,j] atol= EPS;
+            end
+        end
+    end
+
 end
 
 function test_moment_brute_force(pc::ProbCircuit, lc::LogisticCircuit, data, CLASSES::Int, moment::Int)
@@ -84,7 +107,8 @@ end
             missing missing missing 1;
             missing missing missing 0;
             ])
-
+            
+    data = DataFrame(map(x -> (ismissing(x) ? missing : Bool(x)) , Matrix(data)))
     test_expectation_brute_force(pc, lc, data, CLASSES)
 
     # Big circuit (15 Var)


### PR DESCRIPTION
Got some code working for bit circuit for pair of circuits. Took some debugging but now the numbers for expectation match with other implementations.

Todo:
- [x] Helper functions
- [x] CUDA version
- [x] Add units tests for cpu version
- [x] Tests for CUDA version
- [x] See if can optimize and parallelize more on both the CPU/GPU versions.
- [x] Memory optimization? (comment 2)
- [x] Good Benchmark to see how much faster (from small to big cases)
having pr-constraint by itself is useful to have.
- [x] Easy and Efficient Support for batching (by reusing memory etc)
    - [x] See commnet 5, seems much faster  

Comments:
1. Did not add Pair leaves for constant nodes (TRUE,FALSE) probably won't need them. But added for literals pairs that don't agree like (-3 and 3) but probably don't need those either as its always not satisfied.

2. Right now had to also store bit circuit for both the PC and LC as well, maybe can optimize that part. This was to get the paramters easier. Without having to repeat them.

3.~~In small cases its not faster really. In the biggest case I tried its about 1.5-2x times faster than the other two implementations I tried. Probably still room for optimization, did not use many of the tricks yet like `@views`.~~

4. Runtime + Batching: (RTX)

```
training set has 36 variables and 935 samples.
Probablistic Circuit with 27493 nodes and 16272 parameters.
Regression Circuit with 1076 nodes and 659 parameters.
pc nodes 27493, lc nodes 1076, data (935, 36)  
  6.778533 seconds (6.28 M allocations: 2.853 GiB, 4.33% gc time)
  4.903041 seconds (5.64 M allocations: 10.759 GiB, 19.88% gc time)
  3.762878 seconds (3.06 M allocations: 9.933 GiB, 12.06% gc time)
no_agree(EPS=5.0e-5) 0
  0.666297 seconds (2.69 M CPU allocations: 141.079 MiB, 8.76% gc time) (297 GPU allocations: 766.406 MiB, 0.63% gc time of which 93.96% spent allocating)
no_agree(EPS=5.0e-5) 0
  0.044030 seconds (112.21 k CPU allocations: 6.541 MiB) (259 GPU allocations: 45.304 MiB, 0.37% gc time)
PC   bit nodes  (4, 12465)), edges (3, 16272)
Pair bit nodes  (6, 99686)), edges (5, 248450)
no_agree(EPS=5.0e-5) 0
```
a. Recursive Exp
b. Bit circuit cpu
c. Bit circuit cpu & reuse bit circuit + memories
d.  Bit circuit gpu
e.  Bit circuit gpu & reuse bitcuit + memories
