### PR TITLE
Stop transformation steps when no longer possible and add verbose flag

### DIFF
--- a/src/mixtures/em.jl
+++ b/src/mixtures/em.jl
@@ -1,10 +1,10 @@
-export one_step_em, 
-    component_weights_per_example, 
-    initial_weights, 
+export one_step_em,
+    component_weights_per_example,
+    initial_weights,
     clustering,
-    log_likelihood_per_instance_per_component, 
-    estimate_parameters_cached, 
-    learn_circuit_mixture, 
+    log_likelihood_per_instance_per_component,
+    estimate_parameters_cached,
+    learn_circuit_mixture,
     learn_strudel
 
 using Statistics: mean
@@ -67,13 +67,13 @@ end
 
 function log_likelihood_per_instance_per_component(pc::SharedProbCircuit, data::DataFrame, values::Matrix{UInt64}, flows::Matrix{UInt64})
     @assert isbinarydata(data) "Can only calculate EVI on Bool data"
-    
+
     N = num_examples(data)
     num_mix = num_components(pc)
     log_likelihoods = zeros(Float64, N, num_mix)
     indices = init_array(Bool, N)::BitVector
-    
-    
+
+
     ll(n::SharedProbCircuit) = ()
     ll(n::SharedSumNode) = begin
         if num_children(n) != 1 # other nodes have no effect on likelihood
@@ -90,7 +90,7 @@ function log_likelihood_per_instance_per_component(pc::SharedProbCircuit, data::
     log_likelihoods
 end
 
-function estimate_parameters_cached(pc::SharedProbCircuit, example_weights::Matrix{Float64}, 
+function estimate_parameters_cached(pc::SharedProbCircuit, example_weights::Matrix{Float64},
         values::Matrix{UInt64}, flows::Matrix{UInt64}; pseudocount::Float64)
     N = size(example_weights, 1)
     foreach(pc) do pn
@@ -119,12 +119,14 @@ See "Strudel: Learning Structured-Decomposable Probabilistic Circuits. [arxiv.or
 """
 function learn_strudel(train_x; num_mix = 5,
     pseudocount=1.0,
-    init_maxiter = 10, 
-    em_maxiter = 20)
+    init_maxiter = 10,
+    em_maxiter = 20,
+    verbose = true)
 
-    pc = learn_circuit(train_x, maxiter=init_maxiter)
-    learn_circuit_mixture(pc, train_x; num_mix = num_mix, pseudocount= pseudocount, em_maxiter=em_maxiter)
-end  
+    pc = learn_circuit(train_x; maxiter = init_maxiter, verbose = verbose)
+    learn_circuit_mixture(pc, train_x; num_mix = num_mix, pseudocount = pseudocount,
+                          em_maxiter = em_maxiter, verbose = verbose)
+end
 
 
 """
@@ -135,7 +137,8 @@ Given a circuit, learns a mixture of structure decomposable circuits based on th
 function learn_circuit_mixture(pc, data;
         num_mix=5,
         pseudocount=1.0,
-        em_maxiter=20)
+        em_maxiter=20,
+        verbose = true)
 
     spc = compile(SharedProbCircuit, pc, num_mix)
     values, flows = satisfies_flows(spc, data)
@@ -146,7 +149,7 @@ function learn_circuit_mixture(pc, data;
     for iter in 1 : em_maxiter
         @assert isapprox(sum(component_weights), 1.0; atol=1e-10)
         lls, component_weights = one_step_em(spc, data, values, flows, component_weights; pseudocount=pseudocount)
-        println("EM Iteration $iter/$em_maxiter. Log likelihood $(mean(lls))")
+        verbose && println("EM Iteration $iter/$em_maxiter. Log likelihood $(mean(lls))")
     end
     spc, component_weights, lls
 end

--- a/src/structurelearner/heuristics.jl
+++ b/src/structurelearner/heuristics.jl
@@ -46,8 +46,9 @@ function heuristic_loss(circuit::LogicCircuit, train_x; pick_edge="eFlow", pick_
     else
         weights = nothing
     end
-    
+
     candidates, variable_scope = split_candidates(circuit)
+    if isempty(candidates) return nothing end
     values, flows = satisfies_flows(circuit, train_x; weights = nothing) # Do not use samples weights here
     if pick_edge == "eFlow"
         edge, flow = eFlow(values, flows, candidates)

--- a/test/queries/likelihood_tests.jl
+++ b/test/queries/likelihood_tests.jl
@@ -46,8 +46,8 @@ include("../helper/gpu.jl")
 
     # Test Sturdel EVI
     samples, _ = sample(prob_circuit, 100000)
-    mix, weights, _ = @suppress_out learn_strudel(DataFrame(convert(BitArray, samples)); num_mix = 10,
-                                    init_maxiter = 20, em_maxiter = 100)
+    mix, weights, _ = learn_strudel(DataFrame(convert(BitArray, samples)); num_mix = 10,
+                                    init_maxiter = 20, em_maxiter = 100, verbose = false)
     mix_calc_prob = exp.(EVI(mix, data, weights))
 
     @test true_prob ≈ mix_calc_prob atol = 0.1

--- a/test/queries/marginal_flow_tests.jl
+++ b/test/queries/marginal_flow_tests.jl
@@ -65,8 +65,8 @@ include("../helper/gpu.jl")
 
     # Strudel Marginal Flow Test
     samples, _ = sample(prob_circuit, 100000)
-    mix, weights, _ = @suppress_out learn_strudel(DataFrame(convert(BitArray, samples)); 
-                                        num_mix = 10, init_maxiter = 20, em_maxiter = 100)
+    mix, weights, _ = learn_strudel(DataFrame(convert(BitArray, samples)); num_mix = 10,
+                                    init_maxiter = 20, em_maxiter = 100, verbose = false)
     mix_calc_prob = exp.(MAR(mix, data_marg, weights))
     @test true_prob ≈ mix_calc_prob atol = 0.1
     test_complete_mar(mix, data_full, weights, 0.1)

--- a/test/structurelearner/learner_tests.jl
+++ b/test/structurelearner/learner_tests.jl
@@ -46,4 +46,8 @@ using Suppressor
     @test num_parameters(pc3) == 60
     @test num_nodes(pc3) == 88
     @test log_likelihood_avg(pc3, data) ≈ -3.0466585640216746 atol=1e-6
+
+    # Test when there are more iterations than candidates.
+    data = DataFrame(convert(BitArray, rand(Bool, 100, 4)))
+    @test_nowarn pc = learn_circuit(data; maxiter = 100, verbose = false)
 end


### PR DESCRIPTION
Hi,

When having a high enough `maxiter` on `learn_circuit` (or `init_maxiter` on `learn_strudel`), Juice spits out the following error.

```
ERROR: ArgumentError: collection must be non-empty
Stacktrace:
 [1] _findmax(::Array{Any,1}, ::Colon) at ./array.jl:2197
 [2] #findmax#654 at ./reducedim.jl:887 [inlined]
 [3] findmax(::Array{Any,1}) at ./reducedim.jl:887
 [4] eFlow(::Array{UInt64,2}, ::Array{UInt64,2}, ::Array{Tuple{Node,Node},1}) at /home/renatogeh/.julia/packages/ProbabilisticCircuits/Uh1Ay/src/structurelearner/heuristics.jl:11
 [5] heuristic_loss(::StructSumNode, ::DataFrame; pick_edge::String, pick_var::String) at /home/renatogeh/.julia/packages/ProbabilisticCircuits/Uh1Ay/src/structurelearner/heuristics.jl:53
 [6] loss at /home/renatogeh/.julia/packages/ProbabilisticCircuits/Uh1Ay/src/structurelearner/learner.jl:40 [inlined]
 [7] split_step(::StructSumNode; loss::ProbabilisticCircuits.var"#loss#343"{String,String,Nothing,DataFrame}, depth::Int64, sanity_check::Bool) at /home/renatogeh/.julia/packages/LogicCircuits/Z9ob4/src/transformations.jl:347
 [8] (::ProbabilisticCircuits.var"#pc_split_step#344"{Int64,Float64,Bool,Int64,Bool,Float64,DataFrame,ProbabilisticCircuits.var"#loss#343"{String,String,Nothing,DataFrame}})(::StructSumNode) at /home/renatogeh/.julia/packages/ProbabilisticCircuits/Uh1Ay/src/structurelearner/learner.jl:44
 [9] struct_learn(::StructSumNode; primitives::Array{ProbabilisticCircuits.var"#pc_split_step#344"{Int64,Float64,Bool,Int64,Bool,Float64,DataFrame,ProbabilisticCircuits.var"#loss#343"{String,String,Nothing,DataFrame}},1}, kwargs::Dict{ProbabilisticCircuits.var"#pc_split_step#344"{Int64,Float64,Bool,Int64,Bool,Float64,DataFrame,ProbabilisticCircuits.var"#loss#343"{String,String,Nothing,DataFrame}},Tuple{}}, maxiter::Int64, stop::ProbabilisticCircuits.var"#log_per_iter#345"{Int64,Int64,Bool,DataFrame}) at /home/renatogeh/.julia/packages/LogicCircuits/Z9ob4/src/transformations.jl:362
 [10] learn_circuit(::DataFrame, ::StructSumNode, ::PlainVtreeInnerNode; pick_edge::String, pick_var::String, depth::Int64, pseudocount::Float64, sanity_check::Bool, maxiter::Int64, seed::Nothing, return_vtree::Bool, batch_size::Int64, splitting_data::Nothing, use_gpu::Bool, entropy_reg::Float64) at /home/renatogeh/.julia/packages/ProbabilisticCircuits/Uh1Ay/src/structurelearner/learner.jl:65
 [11] learn_circuit(::DataFrame; pick_edge::String, pick_var::String, depth::Int64, pseudocount::Float64, entropy_reg::Float64, sanity_check::Bool, maxiter::Int64, seed::Nothing, return_vtree::Bool) at /home/renatogeh/.julia/packages/ProbabilisticCircuits/Uh1Ay/src/structurelearner/learner.jl:20
 [12] top-level scope at REPL[31]:1
 [13] run_repl(::REPL.AbstractREPL, ::Any) at /build/julia/src/julia-1.5.3/usr/share/julia/stdlib/v1.5/REPL/src/REPL.jl:288
```

This is because there are no more possible edges to apply the split operation on. Instead of throwing out an error, Juice should probably stop the split iteration gracefully and skip to the next step of learning.

This PR addresses this issue and early stops when no longer possible to apply any transformation steps. It also adds a verbose flag to `learn_circuit` and `learn_strudel` to suppress the printing when not needed.

Here's a minimal reproducible example for the above stacktrace:

```julia
using ProbabilisticCircuits, DataFrames
D = DataFrame(convert(BitArray, rand(Bool, 100, 4)))
pc = learn_circuit(D; maxiter = 50)
```

Thanks