### PR TITLE
Add SDD to PSDD compilation

### DIFF
--- a/src/structured_prob_nodes.jl
+++ b/src/structured_prob_nodes.jl
@@ -135,7 +135,7 @@ function compile(::Type{<:StructProbCircuit}, vtree::Vtree, circuit::LogicCircui
     foldup_aggregate(circuit, f_con, f_lit, f_a, f_o, StructProbCircuit)
 end
 
-function Base.convert(::Type{<:StructProbCircuit}, sdd::Sdd)::StructProbCircuit
+function compile(::Type{<:StructProbCircuit}, sdd::Sdd)::StructProbCircuit
     lc = LogicCircuit(sdd)
     plc = propagate_constants(lc, remove_unary=true)
     structplc = compile(StructLogicCircuit, vtree(sdd), plc)

--- a/src/structured_prob_nodes.jl
+++ b/src/structured_prob_nodes.jl
@@ -135,6 +135,76 @@ function compile(::Type{<:StructProbCircuit}, vtree::Vtree, circuit::LogicCircui
     foldup_aggregate(circuit, f_con, f_lit, f_a, f_o, StructProbCircuit)
 end
 
+function Base.convert(::Type{<:StructProbCircuit}, sdd::Sdd)::StructProbCircuit
+    L = Dict{Int32, StructProbLiteralNode}()
+    visited = Dict{Sdd, StructProbCircuit}()
+    Sc_sdd = variables_by_node(sdd)
+    ⊤_node = SddTrueNode(false, nothing)
+    function get_lit(l::Int32, V::Vtree, L::Dict{Int32, StructProbLiteralNode})::StructProbLiteralNode
+      if !haskey(L, l)
+        node = StructProbLiteralNode(l, V)
+        L[l] = node
+        return node
+      end
+      return L[l]
+    end
+    function passdown(S::Sdd, V::Vtree, ignore::Bool = false)::StructProbCircuit
+        if !ignore && haskey(visited, S) return visited[S] end
+        if S isa SddTrueNode
+            Sc = variables(V)
+            if length(Sc) == 1
+                l = convert(Int32, first(Sc))
+                return StructSumNode([get_lit(l, V, L), get_lit(-l, V, L)], V)
+            end
+            # Fully factorize.
+            left, right = passdown(S, V.left, true), passdown(S, V.right, true)
+            return StructSumNode([StructMulNode(left, right, V)], V)
+        elseif S isa SddLiteralNode
+            l = S.literal
+            Sc = variables(V)
+            if length(Sc) == 1 return get_lit(l, V, L) end
+            v = abs(l)
+            left = passdown(v ∈ variables(V.left) ? S : ⊤_node, V.left, true)
+            right = passdown(v ∈ variables(V.right) ? S : ⊤_node, V.right, true)
+            return StructSumNode([StructMulNode(left, right, V)], V)
+        end
+        # Else, disjunction node.
+        ch = Vector{StructProbCircuit}()
+        for c ∈ S.children
+            if c.sub isa SddFalseNode continue end
+            if haskey(visited, c)
+                push!(ch, visited[c])
+                continue
+            end
+            p = passdown(c.prime, V.left)
+            # Corner case for when SDD is not smooth on the left. Add missing variables.
+            if !(V.left isa PlainVtreeLeafNode)
+                if V.left.left isa PlainVtreeLeafNode && V.left.left.var ∉ variables(vtree(p))
+                    p = StructSumNode([StructMulNode(passdown(⊤_node, V.left.left, true), p, V.left)], V.left)
+                end; if V.left.right isa PlainVtreeLeafNode && V.left.right.var ∉ variables(vtree(p))
+                    p = StructSumNode([StructMulNode(p, passdown(⊤_node, V.left.right, true), V.left)], V.left)
+                end
+            end
+            s = passdown(c.sub, V.right)
+            # Corner case for when SDD is not smooth on the right. Add missing variables.
+            if !(V.right isa PlainVtreeLeafNode)
+                if V.right.left isa PlainVtreeLeafNode && V.right.left.var ∉ variables(vtree(s))
+                    s = StructSumNode([StructMulNode(passdown(⊤_node, V.right.left, true), s, V.right)], V.right)
+                end; if V.right.right isa PlainVtreeLeafNode && V.right.right.var ∉ variables(vtree(s))
+                    s = StructSumNode([StructMulNode(s, passdown(⊤_node, V.right.right, true), V.right)], V.right)
+                end
+            end
+            e = StructMulNode(p, s, V)
+            visited[c] = e
+            push!(ch, e)
+        end
+        sum = StructSumNode(ch, V)
+        visited[S] = sum
+        return sum
+    end
+    return passdown(sdd, Vtree(sdd.vtree))
+end
+
 function fully_factorized_circuit(::Type{<:ProbCircuit}, vtree::Vtree)
     ff_logic_circuit = fully_factorized_circuit(PlainStructLogicCircuit, vtree)
     compile(StructProbCircuit, vtree, ff_logic_circuit)

--- a/test/structured_prob_nodes_tests.jl
+++ b/test/structured_prob_nodes_tests.jl
@@ -122,20 +122,19 @@ using DataFrames: DataFrame
 
     # Convert tests
     function apply_test_cnf(n_vars::Int, cnf_path::String)
-        vtree = Vtree(n_vars, :random)
-        println("Compiling...")
-        sdd = compile(SddMgr(vtree), zoo_cnf(cnf_path))
-        @test num_variables(sdd) == n_vars
-        println("Converting...")
-        psdd = convert(StructProbCircuit, sdd)
-        @test num_variables(psdd) == n_vars
-        @test issmooth(psdd)
-        @test isdecomposable(psdd)
-        @test isdeterministic(psdd)
-        @test respects_vtree(psdd, vtree)
-        data = DataFrame(convert(BitMatrix, rand(Bool, 100, n_vars)))
-        println("Testing data...")
-        @test all(sdd(data) .== (EVI(psdd, data) .!=  -Inf))
+        for i in 1:10
+            vtree = Vtree(n_vars, :random)
+            sdd = compile(SddMgr(vtree), zoo_cnf(cnf_path))
+            @test num_variables(sdd) == n_vars
+            psdd = convert(StructProbCircuit, sdd)
+            @test num_variables(psdd) == n_vars
+            @test issmooth(psdd)
+            @test isdecomposable(psdd)
+            @test isdeterministic(psdd)
+            @test respects_vtree(psdd, vtree)
+            data = DataFrame(convert(BitMatrix, rand(Bool, 100, n_vars)))
+            @test all(sdd(data) .== (EVI(psdd, data) .!=  -Inf))
+        end
         nothing
     end
     apply_test_cnf(17, "easy/C17_mince.cnf")

--- a/test/structured_prob_nodes_tests.jl
+++ b/test/structured_prob_nodes_tests.jl
@@ -126,7 +126,7 @@ using DataFrames: DataFrame
             vtree = Vtree(n_vars, :random)
             sdd = compile(SddMgr(vtree), zoo_cnf(cnf_path))
             @test num_variables(sdd) == n_vars
-            psdd = convert(StructProbCircuit, sdd)
+            psdd = compile(StructProbCircuit, sdd)
             @test num_variables(psdd) == n_vars
             @test issmooth(psdd)
             @test isdecomposable(psdd)

--- a/test/structured_prob_nodes_tests.jl
+++ b/test/structured_prob_nodes_tests.jl
@@ -139,7 +139,7 @@ using DataFrames: DataFrame
         nothing
     end
     apply_test_cnf(17, "easy/C17_mince.cnf")
-    apply_test_cnf(15, "easy/majority_mince.cnf")
+    apply_test_cnf(14, "easy/majority_mince.cnf")
     apply_test_cnf(21, "easy/b1_mince.cnf")
     apply_test_cnf(20, "easy/cm152a_mince.cnf")
 end


### PR DESCRIPTION
Adds a function `convert(::Type{<:StructProbCircuit}, sdd::Sdd)` to "convert" an SDD into a PSDD.

There are still some bugs to figure out (tests do not pass), but since this was mentioned in #53, I'm pushing this as a WIP PR.